### PR TITLE
イベント詳細画面を表示させる

### DIFF
--- a/src/app/event/[id]/page.js
+++ b/src/app/event/[id]/page.js
@@ -1,0 +1,61 @@
+// Supabaseのクライアントインスタンスをインポート
+import { supabase } from "../../../../utils/supabase";
+// 404ページ表示用の関数をインポート
+import { notFound } from "next/navigation";
+// EventDetailコンポーネントをインポート
+import EventDetail from "@/components/eventdetail/EventDetail";
+
+/**
+ * ページの内容に応じて、メタデータを動的に生成する関数
+ * @param {object} props
+ * @param {Promise<object>} props.params - URLの動的な部分を含むPromiseライクなオブジェクト
+ * @returns {Promise<object>} Next.jsが使用するメタデータオブジェクト
+ */
+export async function generateMetadata({ params }) {
+  const { id } = await params;
+
+  // SEOに必要なデータ（名前と説明文）だけを先に取得します
+  const { data: event } = await supabase
+    .from("events")
+    .select("name, short_description")
+    .eq("id", id)
+    .single();
+
+  // もしスポットが見つからなかった場合のデフォルトタイトル
+  if (!event) {
+    return {
+      title: "スポットが見つかりません | おでかけカレンダー",
+    };
+  }
+
+  // 見つかったスポットの名前と説明をメタデータとして設定
+  return {
+    title: `${event.name} | おでかけカレンダー`,
+    description: event.short_description || "詳細な情報はありません",
+  };
+}
+
+/**
+ * 観光地の詳細ページを生成するサーバーコンポーネント
+ * @param {object} props - コンポーネントのプロパティ
+ * @param {Promise<object>} props.params - URLから渡されるパラメータ ({ id: '...' })
+ */
+export default async function EventDetailPage({ params }) {
+  const { id } = await params;
+
+  // 'spots'テーブルから、指定されたIDのデータを取得
+  const { data: event, error } = await supabase
+    .from("events")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  // データ取得中にエラーが発生した場合の処理
+  if (error) {
+    console.error("観光地データの取得に失敗しました:", error.message);
+    notFound();
+  }
+
+  // 取得したデータを使ってページをレンダリング
+  return <EventDetail event={event} />;
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -12,7 +12,7 @@ export default async function Page() {
 
   // データ取得中にエラーが発生した場合の処理
   if (error) {
-    console.error("観光地データの取得に失敗しました:", error.message);
+    console.error("イベントデータの取得に失敗しました:", error.message);
     notFound();
   }
 

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -24,7 +24,6 @@ import styled from "@emotion/styled";
 // --- Emotionでスタイルを定義 ---
 // カレンダー全体を包むスタイル
 const CalendarContainer = styled.div`
-  padding: 16px;
   background-color: #fff;
   width: 100%;
   max-width: 380px;

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -182,7 +182,6 @@ export default function Calendar({ selectedDate, onDateChange, events }) {
           }
         });
       }
-
       return acc; // 最終的に { '2025-09-08': ['祭り'], '2025-09-15': ['スポーツ', '教育'] } のようなオブジェクトが出来上がる
     }, {});
   }, [events]); // []の中にあるeventsが変わった時だけ、この中の処理が実行される

--- a/src/components/calendar/Homepage.jsx
+++ b/src/components/calendar/Homepage.jsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 // useStateフックインポート
 import { useState } from "react";
 // 日付比較用のisSameDayをインポート
-import { isSameDay } from "date-fns";
+import { isSameDay, startOfDay } from "date-fns";
 // Calendarコンポーネントをインポート
 import Calendar from "./Calendar";
 // EventCardコンポーネントをインポート
@@ -50,9 +50,17 @@ export default function Homepage({ events }) {
   };
 
   // 選択された日に開催されるイベントだけを絞り込む
-  const filteredEvents = events.filter(event =>
-    isSameDay(new Date(event.start_datetime), selectedDate)
-  );
+  const filteredEvents = events.filter(event => {
+    // 選択された日付の0時0分を取得（時間の影響をなくすため）
+    const selectedDay = startOfDay(selectedDate);
+
+    // イベントの開始日と終了日の0時0分を取得
+    const eventStartDay = startOfDay(new Date(event.start_datetime));
+    const eventEndDay = startOfDay(new Date(event.end_datetime));
+
+    // 選択された日が、イベントの開始日以降 AND 終了日以前 であればtrueを返す
+    return selectedDay >= eventStartDay && selectedDay <= eventEndDay;
+  });
 
   return (
     <HomepageWrapper>
@@ -68,17 +76,7 @@ export default function Homepage({ events }) {
         {/* 絞り込んだイベントだけをEventCardで表示する */}
         {filteredEvents.length > 0 ? (
           filteredEvents.map(event => (
-            <EventCard
-              key={event.id}
-              eventId={event.id}
-              eventName={event.name}
-              eventCategory={event.category}
-              eventArea={event.area}
-              eventShortDescription={event.short_description}
-              eventStartDatetime={event.start_dattime}
-              eventEndDatetime={event.end_dattime}
-              eventImageUrl={event.image_url}
-            />
+            <EventCard key={event.id} event={event} />
           ))
         ) : (
           <p>この日のイベントはありません。</p>

--- a/src/components/calendar/Homepage.jsx
+++ b/src/components/calendar/Homepage.jsx
@@ -68,7 +68,17 @@ export default function Homepage({ events }) {
         {/* 絞り込んだイベントだけをEventCardで表示する */}
         {filteredEvents.length > 0 ? (
           filteredEvents.map(event => (
-            <EventCard key={event.id} event={event} />
+            <EventCard
+              key={event.id}
+              eventId={event.id}
+              eventName={event.name}
+              eventCategory={event.category}
+              eventArea={event.area}
+              eventShortDescription={event.short_description}
+              eventStartDatetime={event.start_dattime}
+              eventEndDatetime={event.end_dattime}
+              eventImageUrl={event.image_url}
+            />
           ))
         ) : (
           <p>この日のイベントはありません。</p>

--- a/src/components/eventdetail/EventDetail.jsx
+++ b/src/components/eventdetail/EventDetail.jsx
@@ -1,0 +1,227 @@
+// クライアントサイドで動作することを宣言
+"use client";
+
+import styled from "@emotion/styled";
+// 日付のフォーマットを整えるためにdate-fnsからformatをインポート
+import { format } from "date-fns";
+// 日本語表示のためのロケールをインポート
+import { ja } from "date-fns/locale";
+// アイコン表示用のライブラリから、使いたいアイコンをインポート
+import {
+  FaCalendarAlt,
+  FaMapMarkerAlt,
+  FaYenSign,
+  FaUsers,
+  FaLink,
+  FaUser,
+} from "react-icons/fa";
+
+// --- Emotionでスタイル定義 ---
+const DetailWrapper = styled.div`
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  /* HeaderやTabBarに隠れないように上下のpaddingを多めにとる */
+  padding: 80px 16px 90px;
+  background-color: #fff;
+`;
+
+const MainImage = styled.img`
+  width: 100%;
+  height: 250px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+`;
+
+const Title = styled.h1`
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+  line-height: 1.4;
+`;
+
+const SubInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 0.9rem;
+  color: #555;
+  margin-bottom: 24px;
+
+  /* アイコンとテキストを縦中央揃えにする */
+  svg {
+    margin-right: 4px;
+    vertical-align: middle;
+  }
+`;
+
+const Description = styled.p`
+  font-size: 1rem;
+  line-height: 1.8;
+  color: #333;
+  white-space: pre-wrap; /* 改行をそのまま表示するための設定 */
+  margin-bottom: 32px;
+`;
+
+const InfoTable = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 32px;
+  font-size: 0.9rem;
+`;
+
+const TableRow = styled.tr`
+  border-bottom: 1px solid #eee;
+`;
+
+const TableHeader = styled.th`
+  text-align: left;
+  padding: 12px 8px;
+  width: 100px;
+  color: #777;
+  vertical-align: top;
+
+  svg {
+    margin-right: 6px;
+    vertical-align: middle;
+  }
+`;
+
+const TableCell = styled.td`
+  padding: 12px 8px;
+  color: #333;
+
+  /* aタグのスタイル */
+  a {
+    color: #007bff;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
+const MapWrapper = styled.div`
+  h2 {
+    font-size: 1.2rem;
+    margin-bottom: 16px;
+  }
+`;
+
+const MapIframe = styled.iframe`
+  width: 100%;
+  height: 300px;
+  border: none;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+`;
+
+/**
+ * イベントの詳細情報を表示するクライアントコンポーネント
+ * @param {{ event: object }} props - 表示するイベントのデータ
+ */
+export default function EventDetail({ event }) {
+  // eventオブジェクトから必要な情報を取り出す
+  const {
+    name,
+    image_url,
+    start_datetime,
+    end_datetime,
+    organizer,
+    long_description,
+    area,
+    fee,
+    capacity,
+    website_url,
+    latitude,
+    longitude,
+  } = event;
+
+  // Google Mapの埋め込み用URLを生成
+  const googleMapUrl = `https://maps.google.com/maps?q=${latitude},${longitude}&hl=ja&z=15&output=embed`;
+
+  // 日付のフォーマットを整える関数
+  const formatDateTime = datetime => {
+    if (!datetime) return "未定";
+    return format(new Date(datetime), "M月d日(E) HH:mm", { locale: ja });
+  };
+
+  return (
+    <DetailWrapper>
+      <MainImage src={image_url} alt={name} />
+      <Title>{name}</Title>
+
+      <SubInfo>
+        <span>
+          <FaCalendarAlt />
+          {formatDateTime(start_datetime)}
+        </span>
+        <span>
+          <FaUser />
+          主催: {organizer || "不明"}
+        </span>
+      </SubInfo>
+
+      <Description>{long_description}</Description>
+
+      <InfoTable>
+        <tbody>
+          <TableRow>
+            <TableHeader>
+              <FaCalendarAlt />
+              開催日時
+            </TableHeader>
+            <TableCell>
+              {formatDateTime(start_datetime)} から
+              <br />
+              {formatDateTime(end_datetime)} まで
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableHeader>
+              <FaMapMarkerAlt />
+              開催場所
+            </TableHeader>
+            <TableCell>{area}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableHeader>
+              <FaYenSign />
+              参加費
+            </TableHeader>
+            <TableCell>{fee ? `${fee.toLocaleString()}円` : "無料"}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableHeader>
+              <FaUsers />
+              定員
+            </TableHeader>
+            <TableCell>{capacity ? `${capacity}名` : "制限なし"}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableHeader>
+              <FaLink />
+              公式サイト
+            </TableHeader>
+            <TableCell>
+              {website_url ? (
+                <a href={website_url} target="_blank" rel="noopener noreferrer">
+                  サイトを見る
+                </a>
+              ) : (
+                "なし"
+              )}
+            </TableCell>
+          </TableRow>
+        </tbody>
+      </InfoTable>
+
+      <MapWrapper>
+        <h2>開催場所の地図</h2>
+        <MapIframe src={googleMapUrl} allowFullScreen="" loading="lazy" />
+      </MapWrapper>
+    </DetailWrapper>
+  );
+}

--- a/src/components/ui/EventCard.jsx
+++ b/src/components/ui/EventCard.jsx
@@ -82,21 +82,21 @@ const CategoryTag = styled.p`
 // 開催日時を表示する部分のスタイル
 const DateTime = styled.p`
   margin: 0 0 8px 0;
-  font-size: 0.8rem;
+  font-size: 0.6rem;
   color: #777;
 `;
 
 // 開催場所を表示する部分のスタイル
 const EventArea = styled.p`
   margin: 0 0 8px 0;
-  font-size: 0.8rem;
+  font-size: 0.6rem;
   color: #777;
 `;
 
 // 短い説明文のスタイル
 const Description = styled.p`
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.6rem;
   color: #555;
   line-height: 1.5;
 `;

--- a/src/components/ui/EventCard.jsx
+++ b/src/components/ui/EventCard.jsx
@@ -86,6 +86,13 @@ const DateTime = styled.p`
   color: #777;
 `;
 
+// 開催場所を表示する部分のスタイル
+const EventArea = styled.p`
+  margin: 0 0 8px 0;
+  font-size: 0.8rem;
+  color: #777;
+`;
+
 // 短い説明文のスタイル
 const Description = styled.p`
   margin: 0;
@@ -107,22 +114,22 @@ const Description = styled.p`
  * @param {string} props.eventImageUrl - 観光地の画像URL
  * @returns {JSX.Element} レンダリングされる観光地カードコンポーネント
  */
-export default function EventCard({
-  eventId,
-  eventName,
-  eventArea,
-  eventCategory,
-  eventShortDescription,
-  eventStartDatetime,
-  eventEndDatetime,
-  eventImageUrl,
-}) {
+export default function EventCard({ event }) {
+  // eventオブジェクトから、必要な情報を取り出す
+  const {
+    id,
+    name,
+    area,
+    category,
+    short_description,
+    start_datetime,
+    end_datetime,
+    image_url,
+  } = event;
   // カテゴリ名に対応する背景色とボーダー色を取得する。なければ「その他」の色を使う
-  const bgColor =
-    categoryColors[eventCategory.category] || categoryColors["その他"];
-  const borderColor =
-    categoryBorderColors[eventCategory.category] ||
-    categoryBorderColors["その他"];
+  const categoryName = category || "その他";
+  const bgColor = categoryColors[categoryName];
+  const borderColor = categoryBorderColors[categoryName];
 
   // 日付のフォーマットを整える関数
   const formatDateTime = datetime => {
@@ -132,21 +139,21 @@ export default function EventCard({
   };
 
   return (
-    <Link href={`/event/${eventId}`}>
+    <Link href={`/event/${id}`}>
       {/* CardWrapperに、計算した色をpropsとして渡す */}
       <CardWrapper bgColor={bgColor} borderColor={borderColor}>
         {/* イベント画像を表示。altは画像が表示されない時のための説明文 */}
-        <EventImage src={eventImageUrl} alt={eventName} />
+        <EventImage src={image_url} alt={name} />
 
         <ContentWrapper>
-          <EventTitle>{eventName}</EventTitle>
-          <CategoryTag>{eventCategory || "その他"}</CategoryTag>
+          <EventTitle>{categoryName}</EventTitle>
+          <CategoryTag>{categoryName || "その他"}</CategoryTag>
           {/* 開始日時と終了日時をきれいにフォーマットして表示 */}
           <DateTime>
-            {formatDateTime(eventStartDatetime)} ~{" "}
-            {formatDateTime(eventEndDatetime)}
+            {formatDateTime(start_datetime)} ~ {formatDateTime(end_datetime)}
           </DateTime>
-          <Description>{eventShortDescription}</Description>
+          <eventArea>{area}</eventArea>
+          <Description>{short_description}</Description>
         </ContentWrapper>
       </CardWrapper>
     </Link>

--- a/src/components/ui/EventCard.jsx
+++ b/src/components/ui/EventCard.jsx
@@ -1,6 +1,8 @@
 // クライアントサイドで動作することを宣言
 "use client";
-
+// ページ遷移用Linkコンポーネントをインポート
+import Link from "next/link";
+// Emotionのstyledをインポート
 import styled from "@emotion/styled";
 // 日付のフォーマットを整えるためにdate-fnsからformatをインポート
 import { format } from "date-fns";
@@ -95,12 +97,32 @@ const Description = styled.p`
 /**
  * イベント情報を表示するカードコンポーネント
  * @param {{ event: object }} props - 表示するイベントのデータ
+ * @param {string} props.eventId - イベントの一意なID(詳細ページへのリンクに使用)
+ * @param {string} props.eventName - イベントの名前
+ * @param {string} props.eventArea - イベントのエリア(例：市役所前)
+ * @param {string} props.eventCategory - イベントのカテゴリー
+ * @param {string} props.eventShortDescription - 観光地の短い説明文
+ * @param {int8} props.eventStartDatetime - イベントの開始日時
+ * @param {int8} props.eventEndDatetime - イベントの終了日時
+ * @param {string} props.eventImageUrl - 観光地の画像URL
+ * @returns {JSX.Element} レンダリングされる観光地カードコンポーネント
  */
-export default function EventCard({ event }) {
+export default function EventCard({
+  eventId,
+  eventName,
+  eventArea,
+  eventCategory,
+  eventShortDescription,
+  eventStartDatetime,
+  eventEndDatetime,
+  eventImageUrl,
+}) {
   // カテゴリ名に対応する背景色とボーダー色を取得する。なければ「その他」の色を使う
-  const bgColor = categoryColors[event.category] || categoryColors["その他"];
+  const bgColor =
+    categoryColors[eventCategory.category] || categoryColors["その他"];
   const borderColor =
-    categoryBorderColors[event.category] || categoryBorderColors["その他"];
+    categoryBorderColors[eventCategory.category] ||
+    categoryBorderColors["その他"];
 
   // 日付のフォーマットを整える関数
   const formatDateTime = datetime => {
@@ -110,21 +132,23 @@ export default function EventCard({ event }) {
   };
 
   return (
-    // CardWrapperに、計算した色をpropsとして渡す
-    <CardWrapper bgColor={bgColor} borderColor={borderColor}>
-      {/* イベント画像を表示。altは画像が表示されない時のための説明文 */}
-      <EventImage src={event.image_url} alt={event.name} />
+    <Link href={`/event/${eventId}`}>
+      {/* CardWrapperに、計算した色をpropsとして渡す */}
+      <CardWrapper bgColor={bgColor} borderColor={borderColor}>
+        {/* イベント画像を表示。altは画像が表示されない時のための説明文 */}
+        <EventImage src={eventImageUrl} alt={eventName} />
 
-      <ContentWrapper>
-        <EventTitle>{event.name}</EventTitle>
-        <CategoryTag>{event.category || "その他"}</CategoryTag>
-        {/* 開始日時と終了日時をきれいにフォーマットして表示 */}
-        <DateTime>
-          {formatDateTime(event.start_datetime)} ~{" "}
-          {formatDateTime(event.end_datetime)}
-        </DateTime>
-        <Description>{event.short_description}</Description>
-      </ContentWrapper>
-    </CardWrapper>
+        <ContentWrapper>
+          <EventTitle>{eventName}</EventTitle>
+          <CategoryTag>{eventCategory || "その他"}</CategoryTag>
+          {/* 開始日時と終了日時をきれいにフォーマットして表示 */}
+          <DateTime>
+            {formatDateTime(eventStartDatetime)} ~{" "}
+            {formatDateTime(eventEndDatetime)}
+          </DateTime>
+          <Description>{eventShortDescription}</Description>
+        </ContentWrapper>
+      </CardWrapper>
+    </Link>
   );
 }

--- a/src/components/ui/EventCard.jsx
+++ b/src/components/ui/EventCard.jsx
@@ -152,7 +152,7 @@ export default function EventCard({ event }) {
           <DateTime>
             {formatDateTime(start_datetime)} ~ {formatDateTime(end_datetime)}
           </DateTime>
-          <eventArea>{area}</eventArea>
+          <EventArea>{area}</EventArea>
           <Description>{short_description}</Description>
         </ContentWrapper>
       </CardWrapper>


### PR DESCRIPTION
### イベント詳細ページの作成と、ページ遷移機能の実装

### 1. EventCard.jsx の改造 

- カード全体を、Next.jsのページ遷移機能を持つ<Link>コンポーネントで囲んだ。
- hrefプロパティに {/events/${event.id}} のように、イベントごとに違うIDを含んだURLを指定した。

### 2. /events/[id]/page.jsx

- 詳細ページの本体を作った。
- [id]っていう特別なフォルダ名を使うことで、「どんなIDが来ても、このページで対応するよ！」っていう、柔軟なページを作った。
- URLに含まれるidを使って、Supabaseに .eq('id', id).single() っていう特別な呪文でお願いした。
- サーバーで取得した、イベントデータを、表示担当のEventDetailコンポーネントに、propsとして渡してあげた。

### 3. EventDetail.jsx

- サーバーから渡されたデータを使って、ユーザーさんが見る画面を実際に組み立てる、クライアントの部品を作った
- react-iconsを使って、表の中にカレンダーや地図のアイコンを追加した。
- latitude（緯度）とlongitude（経度）のデータを使って、iframeっていうHTMLの機能で、開催場所の地図をページに埋め込んだ。